### PR TITLE
fix: properly display text of mermaid diagrams

### DIFF
--- a/pandoc_kroki_filter.py
+++ b/pandoc_kroki_filter.py
@@ -68,6 +68,8 @@ def kroki(key, value, format_, _):
                 zlib.compress(content.encode("utf-8"), 9)
             ).decode()
             url = KROKI_SERVER + "/" + diagram_type + "/svg/" + encoded
+            if diagram_type == "mermaid":
+                url += "?html-labels=false"
 
             return Para([Image([ident, [], keyvals], caption, [url, typef])])
 


### PR DESCRIPTION
this fix defines uses mermaid's `htmlLabels` option to generate valid svg images outside of browser sessions by passing the corresponding setting to kroki.